### PR TITLE
chore: install codecov

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -1,6 +1,6 @@
 name: API workflow
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   build:

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,7 +1,5 @@
 name: Frontend workflow
-
-on: [push, pull_request]
-
+on: [push]
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -18,3 +16,11 @@ jobs:
       run: npm install
     - name: Run tests and collect coverage
       run: npm run test
+    - uses: codecov/codecov-action@v2
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        verbose: true # optional (default = false)
+        # files: ./coverage/clover.xml
+        # flags: unittests # optional
+        # name: codecov-umbrella # optional
+        # fail_ci_if_error: true # optional (default = false)


### PR DESCRIPTION
# why?

I think it would be helpful to developers if they could see the code coverage
results in the context of a pull request.

# how

This PR installs the [CodeCov][1] tool to help provide reports on the coverage.

[1]: https://github.com/codecov/codecov-action#usage
